### PR TITLE
Handle when the url is nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 xhttp_client-*.tar
 
+# Ignore elixir_ls for vscode
+.elixir_ls
+

--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -88,7 +88,7 @@ defmodule Mojito do
   """
   @spec request(method, String.t(), headers, String.t(), Keyword.t()) ::
           {:ok, response} | {:error, error}
-  def request(method, url, headers \\ [], payload \\ "", opts \\ []) do
+  def request(method, url, headers \\ [], payload \\ "", opts \\ []) when is_binary(url) do
     timeout = opts[:timeout] || @request_timeout
 
     with {:ok, pid} <- Mojito.ConnServer.start_link(),

--- a/lib/mojito/pool.ex
+++ b/lib/mojito/pool.ex
@@ -56,7 +56,7 @@ defmodule Mojito.Pool do
   """
   @spec request(pid, Mojito.method(), String.t(), Mojito.headers(), String.t(), Keyword.t()) ::
           {:ok, Mojito.response()} | {:error, Mojito.error()}
-  def request(pool, method, url, headers \\ [], payload \\ "", opts \\ []) do
+  def request(pool, method, url, headers \\ [], payload \\ "", opts \\ []) when is_binary(url) do
     timeout = opts[:timeout] || @request_timeout
 
     worker_fn = fn worker ->

--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -22,6 +22,12 @@ defmodule MojitoTest do
       it "fails on url without hostname" do
         assert({:error, _} = Mojito.request(:get, "http://"))
       end
+
+      it "fails on a nil url" do
+        assert_raise(FunctionClauseError, fn ->
+          Mojito.request(:get, nil)
+        end)
+      end
     end
 
     context "local server tests" do


### PR DESCRIPTION
Instead of returning an error struct when passing in a `nil` url, this PR causes a functionclause error to be thrown, leading to quicker debugging:

 

> Mojito.request(:get, nil)
> ** (FunctionClauseError) no function clause matching in Mojito.request/5
> 
>     The following arguments were given to Mojito.request/5:
> 
>         # 1
>         :get
> 
>         # 2
>         nil
> 
>         # 3
>         []
> 
>         # 4
>         ""
> 
>         # 5
>         []
> 
>     Attempted function clauses (showing 1 out of 1):
> 
>         def request(method, url, headers, payload, opts) when is_binary(url)
> 
>     (mojito) lib/mojito.ex:91: Mojito.request/5