### PR TITLE
Add a namespace to mojito response messages

### DIFF
--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -122,7 +122,7 @@ defmodule Mojito do
              opts
            ) do
       receive do
-        reply ->
+        {:mojito_response, reply} ->
           GenServer.stop(pid)
           reply
       after

--- a/lib/mojito/pool.ex
+++ b/lib/mojito/pool.ex
@@ -77,7 +77,7 @@ defmodule Mojito.Pool do
            ) do
         :ok ->
           receive do
-            response -> response
+            {:mojito_response, response} -> response
           after
             timeout -> {:error, :timeout}
           end


### PR DESCRIPTION
Mojito lives in the same process as its caller and thus needs to play nice with other messages in its mailbox.
This fixes #14 


The other way to fix this would be to spawn a new PID for each request to ensure it gets its own mailbox (e.g. Task.async/await), but that seems overkill to me.