### PR TITLE
Process-less operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Elixir HTTP client libraries.
 
 HTTPS, one-off requests, connection pooling, and request pipelining are
 supported out of the box.  Mojito supports the same process-less
-architecture as Mint, i.e., it does not spawn a process per request.
+architecture as Mint; i.e., it does not spawn a process per request.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 # Mojito [![Build Status](https://travis-ci.org/appcues/mojito.svg?branch=master)](https://travis-ci.org/appcues/mojito) [![Docs](https://img.shields.io/badge/api-docs-green.svg?style=flat)](https://hexdocs.pm/mojito/Mojito.html) [![Hex.pm Version](http://img.shields.io/hexpm/v/mojito.svg?style=flat)](https://hex.pm/packages/mojito)
 
-Mojito is a simplified HTTP client for Elixir, built using the
+Mojito is an easy-to-use HTTP client for Elixir, built using the
 low-level [Mint client](https://github.com/ericmj/mint).
 
 It provides an interface that will feel familiar to users of other
 Elixir HTTP client libraries.
 
 HTTPS, one-off requests, connection pooling, and request pipelining are
-supported out of the box.
+supported out of the box.  Mojito supports the same process-less
+architecture as Mint, i.e., it does not spawn a process per request.
 
 ## Installation
 
@@ -19,10 +20,33 @@ Add `mojito` to your deps in `mix.exs`:
 
 ## Single-request example
 
-`Mojito.request/5` can be used directly for making individual
-requests:
+`Mojito.request/1` or the equivalent `Mojito.request/5` can be used
+directly for making individual requests:
 
     >>>> Mojito.request(:get, "https://jsonplaceholder.typicode.com/posts/1")
+    {:ok,
+     %Mojito.Response{
+       body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}",
+       headers: [
+         {"content-type", "application/json; charset=utf-8"},
+         {"content-length", "292"},
+         {"connection", "keep-alive"},
+         ...
+       ],
+       status_code: 200
+     }}
+
+`Mojito.request/1,5` does not spawn any additional processes to handle the
+HTTP response; TCP messages are received and handled within the caller
+process.  In the common case, this results in faster performance and
+lower overhead in the Erlang VM.
+
+However, if the caller is also expecting to receive other messages at
+the same time, this can cause conflict.  In this case, it's recommended
+to wrap the call to `Mojito.request/1,5` in `Task.async/1`:
+
+    >>>> task = Task.async(fn () -> Mojito.request(:get, "https://jsonplaceholder.typicode.com/posts/1") end)
+    >>>> Task.await(task)
     {:ok,
      %Mojito.Response{
        body: "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}",
@@ -48,11 +72,15 @@ connections is desired:
 Connection pooling in Mojito is implemented using
 [Poolboy](https://github.com/devinus/poolboy).
 
+Currently, Mojito connection pools should only be used to access a single
+protocol + hostname + port destination; otherwise, connections are
+reused only sporadically.
+
 ## Self-signed SSL/TLS certificates
 
 To accept self-signed certificates in HTTPS connections, you can give the
-`transport_opts: [verify: :verify_none]` option to `Mojito.request/5`
-or `Mojito.Pool.request/6`:
+`transport_opts: [verify: :verify_none]` option to `Mojito.request/1,5`
+or `Mojito.Pool.request/2,6`:
 
     >>>> Mojito.request(:get, "https://localhost:8443/")
     {:error, {:tls_alert, 'bad certificate'}}

--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -75,7 +75,6 @@ defmodule Mojito do
   @type method ::
           :head | :get | :post | :put | :patch | :delete | :options | String.t()
 
-
   @doc ~S"""
   Performs an HTTP request and returns the response.
 
@@ -104,7 +103,6 @@ defmodule Mojito do
     {:error, %Mojito.Error{message: "url cannot be blank"}}
   end
 
-
   def request(method, url, headers, payload, opts) do
     %Mojito.Request{
       method: method,
@@ -114,6 +112,4 @@ defmodule Mojito do
     }
     |> Mojito.Request.request(opts)
   end
-
-
 end

--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -8,13 +8,13 @@ defmodule Mojito do
 
   HTTPS, one-off requests, connection pooling, and request pipelining are
   supported out of the box.  Mojito supports the same process-less
-  architecture as Mint, i.e., it does not spawn a process per request.
+  architecture as Mint; i.e., it does not spawn a process per request.
 
   ## Installation
 
   Add `mojito` to your deps in `mix.exs`:
 
-      {:mojito, "~> 0.2.0"}
+      {:mojito, "~> 0.2.1"}
 
   ## Single-request example
 

--- a/lib/mojito/conn.ex
+++ b/lib/mojito/conn.ex
@@ -14,10 +14,10 @@ defmodule Mojito.Conn do
   Connects to the specified endpoint, returning a connection to the server.
   No requests are made.
   """
-  @spec connect(String.t()) :: {:ok, t} | {:error, any}
-  def connect(url) do
+  @spec connect(String.t(), Keyword.t()) :: {:ok, t} | {:error, any}
+  def connect(url, opts \\ []) do
     with {:ok, protocol, hostname, port} <- Utils.decompose_url(url) do
-      connect(protocol, hostname, port)
+      connect(protocol, hostname, port, opts)
     end
   end
 
@@ -25,7 +25,7 @@ defmodule Mojito.Conn do
   Connects to the server specified in the given URL,
   returning a connection to the server.  No requests are made.
   """
-  @spec connect(String.t(), String.t(), non_neg_integer) ::
+  @spec connect(String.t(), String.t(), non_neg_integer, Keyword.t()) ::
           {:ok, t} | {:error, any}
   def connect(protocol, hostname, port, opts \\ []) do
     :http

--- a/lib/mojito/conn_server.ex
+++ b/lib/mojito/conn_server.ex
@@ -9,13 +9,13 @@ defmodule Mojito.ConnServer do
   @type state :: map
 
   @doc ~S"""
-  Starts an `Mojito.ConnServer`.
+  Starts a `Mojito.ConnServer`.
 
   `Mojito.ConnServer` is a GenServer that handles a single
   `Mojito.Conn`.  It supports automatic reconnection,
   connection keep-alive, and request pipelining.
 
-  It's intended for usage through `Mojito` or `Mojito.Pool`.
+  It's intended for usage through `Mojito.Pool`.
 
   Example:
 
@@ -116,9 +116,8 @@ defmodule Mojito.ConnServer do
         {:error, %{state: :closed}, %{reason: :closed}, _} ->
           {:noreply, close_connections(state)}
 
-        other ->
-          Logger.error(fn -> "got unknown message: #{inspect(other)}" end)
-          raise RuntimeError, other
+        :unknown ->
+          {:noreply, state}
       end
     end
   end

--- a/lib/mojito/conn_server.ex
+++ b/lib/mojito/conn_server.ex
@@ -178,9 +178,7 @@ defmodule Mojito.ConnServer do
     send(pid, {:mojito_response, message})
 
     Logger.debug(fn ->
-      "Mojito.ConnServer #{inspect(self())}: sent response to #{
-        inspect(pid)
-      }"
+      "Mojito.ConnServer #{inspect(self())}: sent response to #{inspect(pid)}"
     end)
   end
 

--- a/lib/mojito/conn_server.ex
+++ b/lib/mojito/conn_server.ex
@@ -113,9 +113,6 @@ defmodule Mojito.ConnServer do
           state = %{state | conn: state_conn}
           {:noreply, apply_resps(state, resps)}
 
-        {:error, %{state: :closed}, %{reason: :closed}, _} ->
-          {:noreply, close_connections(state)}
-
         :unknown ->
           {:noreply, state}
       end
@@ -189,7 +186,7 @@ defmodule Mojito.ConnServer do
           Mojito.headers(),
           String.t(),
           Keyword.t()
-        ) :: {:ok, String.t(), reference} | {:error, any}
+        ) :: {:ok, state, reference} | {:error, any}
   defp do_request(state, reply_to, method, url, headers, payload, opts) do
     with {:ok, state} <- ensure_connection(state, url, opts),
          {:ok, conn, request_ref} <-

--- a/lib/mojito/request.ex
+++ b/lib/mojito/request.ex
@@ -1,0 +1,78 @@
+defmodule Mojito.Request do
+  @moduledoc false
+
+  defstruct [:method, :url, :headers, :payload]
+
+  require Logger
+  alias Mojito.{Conn, Error, Response}
+
+  @request_timeout Application.get_env(:mojito, :request_timeout, 5000)
+
+  def request(%Mojito.Request{} = req, opts \\ []) do
+    timeout = opts[:timeout] || @request_timeout
+
+    with {:ok, conn} <- Conn.connect(req.url, opts),
+         {:ok, conn, _ref} <-
+           Conn.request(
+             conn,
+             req.method,
+             req.url,
+             req.headers,
+             req.payload,
+             opts
+           ) do
+      receive_response(conn, %Response{}, timeout)
+    end
+  end
+
+  defp receive_response(conn, response, timeout) do
+    receive do
+      msg ->
+        case Mint.HTTP.stream(conn.conn, msg) do
+          {:ok, mint_conn, resps} ->
+            conn = %{conn | conn: mint_conn}
+            response = apply_resps(response, resps)
+
+            if response.complete do
+              {:ok, response}
+            else
+              receive_response(conn, response, timeout)
+            end
+
+          {:error, %{state: :closed}, %{reason: :closed}, _} ->
+            {:error, %Error{reason: :closed}}
+
+          :unknown ->
+            receive_response(conn, response, timeout)
+
+          other ->
+            raise RuntimeError,
+                  "unrecognized output from Mint: #{inspect(other)}"
+        end
+    after
+      timeout -> {:error, %Error{reason: :timeout}}
+    end
+  end
+
+  defp apply_resps(response, []), do: response
+
+  defp apply_resps(response, [mint_resp | rest]) do
+    apply_resp(response, mint_resp) |> apply_resps(rest)
+  end
+
+  defp apply_resp(response, {:status, _request_ref, status_code}) do
+    %{response | status_code: status_code}
+  end
+
+  defp apply_resp(response, {:headers, _request_ref, headers}) do
+    %{response | headers: headers}
+  end
+
+  defp apply_resp(response, {:data, _request_ref, chunk}) do
+    %{response | body: [response.body || "" | [chunk]]}
+  end
+
+  defp apply_resp(response, {:done, _request_ref}) do
+    %{response | complete: true, body: :erlang.iolist_to_binary(response.body)}
+  end
+end

--- a/lib/mojito/request.ex
+++ b/lib/mojito/request.ex
@@ -45,9 +45,6 @@ defmodule Mojito.Request do
               receive_response(conn, response, timeout)
             end
 
-          {:error, %{state: :closed}, %{reason: :closed}, _} ->
-            {:error, %Error{reason: :closed}}
-
           :unknown ->
             receive_response(conn, response, timeout)
         end
@@ -71,7 +68,7 @@ defmodule Mojito.Request do
   end
 
   defp apply_resp(response, {:data, _request_ref, chunk}) do
-    %{response | body: [response.body || "" | [chunk]]}
+    %{response | body: [response.body | [chunk]]}
   end
 
   defp apply_resp(response, {:done, _request_ref}) do

--- a/lib/mojito/response.ex
+++ b/lib/mojito/response.ex
@@ -1,7 +1,12 @@
 defmodule Mojito.Response do
   @moduledoc false
 
-  defstruct [:status_code, :headers, :body]
+  defstruct [
+    status_code: nil,
+    headers: [],
+    body: "",
+    complete: false
+  ]
 
   @type t :: Mojito.response()
 end

--- a/lib/mojito/response.ex
+++ b/lib/mojito/response.ex
@@ -1,12 +1,10 @@
 defmodule Mojito.Response do
   @moduledoc false
 
-  defstruct [
-    status_code: nil,
-    headers: [],
-    body: "",
-    complete: false
-  ]
+  defstruct status_code: nil,
+            headers: [],
+            body: "",
+            complete: false
 
   @type t :: Mojito.response()
 end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,6 @@ defmodule Mojito.MixProject do
     [
       {:mint, "~> 0.2"},
       {:castore, "~> 0.1"},
-      {:fuzzyurl, "~> 1.0"},
       {:poolboy, "~> 1.5"},
       {:ex_spec, "~> 2.0", only: :test},
       {:jason, "~> 1.0", only: :test},

--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -140,7 +140,7 @@ defmodule MojitoTest do
           {:ok, %{status_code: 200} = response} = get_with_user("/auth", "hi")
         )
 
-        assert(%{"user" => "hi", "pass" => ""} = Jason.decode!(response.body))
+        assert(%{"user" => "hi", "pass" => nil} = Jason.decode!(response.body))
 
         assert(
           {:ok, %{status_code: 200} = response} =


### PR DESCRIPTION
This PR resolves #5 by changing `Mojito.request` so that no additional processes are created.  TCP messages are received and handled in the caller process.

Also in this PR: 
* Added `%Mojito.Request{}` struct to allow building requests functionally
* Added `Mojito.request/1` and `Mojito.Pool.request/2` using the above struct
* Removed runtime dependency on Fuzzyurl
* Improved docs