### PR TITLE
[WIP] Initial implementation of following redirects

### DIFF
--- a/lib/mojito/redirects.ex
+++ b/lib/mojito/redirects.ex
@@ -1,0 +1,41 @@
+defmodule Mojito.Redirects do
+  def maybe_follow_redirect(
+        last_request,
+        %{status_code: status_code} = last_response
+      ) do
+    case last_request.opts[:follow_redirects] do
+      true ->
+        new_location = Mojito.Headers.get(last_response.headers, "location")
+
+        new_request = %{
+          last_request
+          | url: assemble_redirect_url(last_request.url, new_location)
+        }
+
+        Mojito.request(new_request)
+
+      _ ->
+        {:ok, last_response}
+    end
+  end
+
+  defp assemble_redirect_url(previous_url, location) do
+    previous_uri = URI.parse(previous_url)
+    location_uri = URI.parse(location)
+
+    case location_uri.host do
+      nil ->
+        # relative redirect
+        next_uri = %{
+          previous_uri
+          | path: location_uri.path,
+            query: location_uri.query
+        }
+
+        URI.to_string(next_uri)
+
+      _host ->
+        location
+    end
+  end
+end

--- a/lib/mojito/response.ex
+++ b/lib/mojito/response.ex
@@ -4,7 +4,8 @@ defmodule Mojito.Response do
   defstruct status_code: nil,
             headers: [],
             body: "",
-            complete: false
+            complete: false,
+            location: nil
 
   @type t :: Mojito.response()
 end

--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -309,6 +309,19 @@ defmodule MojitoTest do
           Headers.get(response.headers, "allow")
       )
     end
+
+    it "should not follow redirect by default" do
+      assert({:ok, response} = get("/redirect/1"))
+      assert(302 == response.status_code)
+      assert("You are being redirected" == response.body)
+    end
+
+    it "can follow a redirect" do
+      assert({:ok, response} = get("/redirect/1", follow_redirects: true))
+      assert(200 == response.status_code)
+      assert("Hello world!" == response.body)
+      assert(response.location == "http://localhost:#{@http_port}/")
+    end
   end
 
   context "external tests" do

--- a/test/support/mojito_test_server.ex
+++ b/test/support/mojito_test_server.ex
@@ -94,4 +94,10 @@ defmodule Mojito.TestServer.PlugRouter do
     :timer.sleep(10000)
     send_resp(conn, 200, "ok")
   end
+
+  get "/redirect/1" do
+    conn
+    |> put_resp_header("location", "/")
+    |> send_resp(302, "You are being redirected")
+  end
 end


### PR DESCRIPTION
This is still work in progress, but sending over in case you want to have a look.

In short: I need to follow redirects. HTTPoison / hackney have options of `follow_redirect` and `max_redirect`. I think better names are "follow_redirects" and "max_redirects" so used these instead.

The default behavior should be not to follow redirects, I think.

If you pass option of "follow_redirects: true", I think we should have some low `max_redirects` set, to something like `3`. This means up to 3 redirects will be followed before we error.

The pull request so far implements the infinite redirects, there is no max_redirects option yet and no error handling, also has only basic tests.

Submitting for feedback if you have time to give me some, I'll probably work some more on this over weekend :)