### PR TITLE
Version 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.0 (2019-08-13)
+
+Upgraded to Mint 0.4.0.
+
+Requests are automatically retried when we attempt to reuse a closed
+connection.
+
+Don't pass the URL fragment to Mint when making requests.
+Thanks [@alappe](https://github.com/alappe)!
+
+Improved examples and docs around making POST requests.
+Thanks [@hubertlepicki](https://github.com/hubertlepicki)!
+
+Removed noisy debug output.
+Thanks for the report, [@bcardarella](https://github.com/bcardarella)!
+
 ## 0.3.0 (2019-05-08)
 
 Major refactor.

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Mojito addresses the following design goals:
 
 Add `mojito` to your deps in `mix.exs`:
 
-    {:mojito, "~> 0.3.0"}
+    {:mojito, "~> 0.4.0"}
 
 ## Upgrading from 0.2
 
 Using request methods other than those in the `Mojito` module is deprecated.
 A handful of new config parameters appeared as well.
 
-Upgrading 0.2 to 0.3 cannot be performed safely inside a hot upgrade.
+Upgrading 0.2 to 0.4 cannot be performed safely inside a hot upgrade.
 Deploy a regular release instead.
 
 ## Configuration

--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -184,7 +184,7 @@ defmodule Mojito do
   @type method ::
           :head | :get | :post | :put | :patch | :delete | :options | String.t()
 
-  @type header :: [{String.t(), String.t()}]
+  @type header :: {String.t(), String.t()}
 
   @type headers :: [header]
 
@@ -193,7 +193,7 @@ defmodule Mojito do
           url: String.t(),
           headers: headers | nil,
           body: String.t() | nil,
-          opts: Keyword.t() | nil,
+          opts: Keyword.t() | nil
         }
 
   @type request_kwlist :: [request_field]
@@ -209,12 +209,12 @@ defmodule Mojito do
           status_code: pos_integer,
           headers: headers,
           body: String.t(),
-          complete: boolean,
+          complete: boolean
         }
 
   @type error :: %Mojito.Error{
           reason: any,
-          message: String.t() | nil,
+          message: String.t() | nil
         }
 
   @type pool_opts :: [pool_opt | {:destinations, [{atom, pool_opts}]}]

--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -193,7 +193,7 @@ defmodule Mojito do
           url: String.t(),
           headers: headers | nil,
           body: String.t() | nil,
-          opts: Keyword.t() | nil
+          opts: Keyword.t() | nil,
         }
 
   @type request_kwlist :: [request_field]
@@ -209,12 +209,12 @@ defmodule Mojito do
           status_code: pos_integer,
           headers: headers,
           body: String.t(),
-          complete: boolean
+          complete: boolean,
         }
 
   @type error :: %Mojito.Error{
           reason: any,
-          message: String.t() | nil
+          message: String.t() | nil,
         }
 
   @type pool_opts :: [pool_opt | {:destinations, [{atom, pool_opts}]}]

--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -48,14 +48,14 @@ defmodule Mojito do
 
   Add `mojito` to your deps in `mix.exs`:
 
-      {:mojito, "~> 0.3.0"}
+      {:mojito, "~> 0.4.0"}
 
   ## Upgrading from 0.2
 
   Using request methods other than those in the `Mojito` module is deprecated.
   A handful of new config parameters appeared as well.
 
-  Upgrading 0.2 to 0.3 cannot be performed safely inside a hot upgrade.
+  Upgrading 0.2 to 0.4 cannot be performed safely inside a hot upgrade.
   Deploy a regular release instead.
 
   ## Configuration
@@ -184,7 +184,9 @@ defmodule Mojito do
   @type method ::
           :head | :get | :post | :put | :patch | :delete | :options | String.t()
 
-  @type headers :: [{String.t(), String.t()}]
+  @type header :: [{String.t(), String.t()}]
+
+  @type headers :: [header]
 
   @type request :: %Mojito.Request{
           method: method,
@@ -276,16 +278,12 @@ defmodule Mojito do
           pool -> fn -> Mojito.Pool.Single.request(pool, valid_request) end
         end
 
-      ## Retry connection-closed errors once
-      case request_fn.() |> Mojito.Utils.wrap_return_value() do
-        {:error, %{reason: %{reason: :closed}}} -> request_fn.()
-        other -> other
-      end
+      request_fn.()
     end
   end
 
   @doc ~S"""
-  Perform an HTTP HEAD request and returns the response.
+  Performs an HTTP HEAD request and returns the response.
 
   See `request/1` for documentation.
   """
@@ -296,11 +294,11 @@ defmodule Mojito do
   end
 
   @doc ~S"""
-  Perform an HTTP GET request and returns the response.
+  Performs an HTTP GET request and returns the response.
 
   ## Examples
 
-  Assemble URL with a query string params and fetch it with GET request:
+  Assemble a URL with a query string params and fetch it with GET request:
 
       >>>> "https://www.google.com/search"
       ...> |> URI.parse()
@@ -328,7 +326,7 @@ defmodule Mojito do
   end
 
   @doc ~S"""
-  Perform an HTTP POST request and returns the response.
+  Performs an HTTP POST request and returns the response.
 
   ## Examples
 
@@ -377,7 +375,7 @@ defmodule Mojito do
   end
 
   @doc ~S"""
-  Perform an HTTP PUT request and returns the response.
+  Performs an HTTP PUT request and returns the response.
 
   See `request/1` and `post/4` for documentation and examples.
   """
@@ -388,7 +386,7 @@ defmodule Mojito do
   end
 
   @doc ~S"""
-  Perform an HTTP PATCH request and returns the response.
+  Performs an HTTP PATCH request and returns the response.
 
   See `request/1` and `post/4` for documentation and examples.
   """
@@ -399,9 +397,9 @@ defmodule Mojito do
   end
 
   @doc ~S"""
-  Perform an HTTP DELETE request and returns the response.
+  Performs an HTTP DELETE request and returns the response.
 
-  See `request/1` and `post/4` for documentation and examples.
+  See `request/1` for documentation and examples.
   """
   @spec delete(String.t(), headers, Keyword.t()) ::
           {:ok, response} | {:error, error} | no_return
@@ -410,7 +408,7 @@ defmodule Mojito do
   end
 
   @doc ~S"""
-  Perform an HTTP OPTIONS request and returns the response.
+  Performs an HTTP OPTIONS request and returns the response.
 
   See `request/1` for documentation.
   """

--- a/lib/mojito/conn_server.ex
+++ b/lib/mojito/conn_server.ex
@@ -73,11 +73,7 @@ defmodule Mojito.ConnServer do
      }}
   end
 
-  def terminate(reason, state) do
-    Logger.debug(fn ->
-      "Mojito.ConnServer #{inspect(self())}: terminating (#{inspect(reason)})"
-    end)
-
+  def terminate(_reason, state) do
     close_connections(state)
   end
 
@@ -86,10 +82,6 @@ defmodule Mojito.ConnServer do
         _from,
         state
       ) do
-    Logger.debug(fn ->
-      "Mojito.ConnServer #{inspect(self())}: #{method} #{url}"
-    end)
-
     with {:ok, state, _ref} <-
            do_request(state, reply_to, method, url, headers, body, opts) do
       {:reply, :ok, state}
@@ -100,10 +92,6 @@ defmodule Mojito.ConnServer do
 
   ## `msg` is an incoming chunk of a response
   def handle_info(msg, state) do
-    Logger.debug(fn ->
-      "Mojito.ConnServer #{inspect(self())}: received TCP data #{inspect(msg)}"
-    end)
-
     if !state.conn do
       {:noreply, close_connections(state)}
     else
@@ -126,8 +114,6 @@ defmodule Mojito.ConnServer do
 
   @spec close_connections(state) :: state
   defp close_connections(state) do
-    Logger.debug(fn -> "Mojito.ConnServer #{inspect(self())}: cleaning up" end)
-
     Enum.each(state.reply_tos, fn {_request_ref, reply_to} ->
       respond(reply_to, {:error, :closed})
     end)
@@ -175,10 +161,6 @@ defmodule Mojito.ConnServer do
 
   defp respond(pid, message) do
     send(pid, {:mojito_response, message})
-
-    Logger.debug(fn ->
-      "Mojito.ConnServer #{inspect(self())}: sent response to #{inspect(pid)}"
-    end)
   end
 
   @spec do_request(

--- a/lib/mojito/headers.ex
+++ b/lib/mojito/headers.ex
@@ -185,4 +185,18 @@ defmodule Mojito.Headers do
       {name, Map.get(headers_map, name) |> Enum.join(",")}
     end)
   end
+
+  @doc ~S"""
+  Returns an HTTP Basic Auth header from the given username and password.
+
+  Example:
+
+      iex> Mojito.Headers.auth_header("hello", "world")
+      {"authorization", "Basic aGVsbG86d29ybGQ="}
+  """
+  @spec auth_header(String.t(), String.t()) :: Mojito.header()
+  def auth_header(username, password) do
+    auth64 = "#{username}:#{password}" |> Base.encode64()
+    {"authorization", "Basic #{auth64}"}
+  end
 end

--- a/lib/mojito/pool.ex
+++ b/lib/mojito/pool.ex
@@ -65,7 +65,6 @@ defmodule Mojito.Pool do
   def get_pool(pool_key) do
     case get_pools(pool_key) do
       [] ->
-        Logger.debug("Mojito.Pool: starting pools for #{inspect(pool_key)}")
         opts = pool_opts(pool_key)
         1..opts[:pools] |> Enum.each(fn _ -> start_pool(pool_key) end)
         get_pool(pool_key)

--- a/lib/mojito/pool/single.ex
+++ b/lib/mojito/pool/single.ex
@@ -105,9 +105,10 @@ defmodule Mojito.Pool.Single do
           {:ok, Mojito.response()} | {:error, Mojito.error()}
   def request(pool, request) do
     start_time = time()
-    timeout = request.opts[:timeout] || Config.timeout()
 
     with {:ok, valid_request} <- Request.validate_request(request) do
+      timeout = valid_request.opts[:timeout] || Config.timeout()
+
       case do_request(pool, valid_request) do
         {:error, %Mojito.Error{reason: %{reason: :closed}}} ->
           ## Retry connection-closed errors as many times as we can

--- a/lib/mojito/utils.ex
+++ b/lib/mojito/utils.ex
@@ -74,7 +74,7 @@ defmodule Mojito.Utils do
       joined_url =
         [
           if(uri.path, do: "#{uri.path}", else: ""),
-          if(uri.query, do: "?#{uri.query}", else: "")
+          if(uri.query, do: "?#{uri.query}", else: ""),
         ]
         |> Enum.join("")
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Mojito.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @repo_url "https://github.com/appcues/mojito"
 
   def project do
@@ -46,7 +46,7 @@ defmodule Mojito.MixProject do
 
   defp deps do
     [
-      {:mint, "~> 0.2.1"},
+      {:mint, "~> 0.4.0"},
       {:castore, "~> 0.1"},
       {:poolboy, "~> 1.5"},
       {:ex_spec, "~> 2.0", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.1", "a8905530209152ddb74989fa2a5bd4fa3a2d3ff5d15ad12578caa7460d807c8b", [:mix], [], "hexpm"},
+  "castore": {:hex, :castore, "0.1.2", "81adb0683c4ec8ebb97ad777ec1b050405282d55453df14567a3c73ae25932a6", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
@@ -12,7 +12,7 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
-  "mint": {:hex, :mint, "0.2.1", "a2ec8729fcad5c8b6460e07dfa64b008b3d9697a9f4604cd5684a87b44677c99", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm"},
+  "mint": {:hex, :mint, "0.4.0", "b93a10192957624ed4a8b8641eff1819019c36487bdf49e2b505afd2cc9b7911", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.7.2", "d7b7db7fbd755e8283b6c0a50be71ec0a3d67d9213d74422d9372effc8e87fd1", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_cowboy": {:hex, :plug_cowboy, "1.0.0", "2e2a7d3409746d335f451218b8bb0858301c3de6d668c3052716c909936eb57a", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/mojito/pool/single_test.exs
+++ b/test/mojito/pool/single_test.exs
@@ -83,5 +83,14 @@ defmodule Mojito.Pool.SingleTest do
         assert({:ready, 2, 0, 0} = :poolboy.status(pool_name))
       end)
     end
+
+    it "retries request when connection was closed" do
+      with_pool(fn pool_name ->
+        1..100
+        |> Enum.each(fn _ ->
+          assert({:ok, _resp} = get(pool_name, "/"))
+        end)
+      end)
+    end
   end
 end


### PR DESCRIPTION
# Changelog

## 0.4.0 (2019-08-13)

Upgraded to Mint 0.4.0.

Requests are automatically retried when we attempt to reuse a closed
connection.

Don't pass the URL fragment to Mint when making requests.
Thanks [@alappe](https://github.com/alappe)!

Improved examples and docs around making POST requests.
Thanks [@hubertlepicki](https://github.com/hubertlepicki)!

Removed noisy debug output.
Thanks for the report, [@bcardarella](https://github.com/bcardarella)!

