### PR TITLE
Don't return timed-out response on the next request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.0 (2018-08-21)
+
+Fixed bug where timed-out responses would arrive in connection with
+the next request from that caller.  Thanks for the report and the
+test case, [@seanedwards](https://github.com/seanedwards)!
+
+Refactored to use `%Mojito.Request{}` structs more consistently across
+internal Mojito functions.
+
 ## 0.4.0 (2019-08-13)
 
 Upgraded to Mint 0.4.0.

--- a/README.md
+++ b/README.md
@@ -50,15 +50,22 @@ Mojito addresses the following design goals:
 
 Add `mojito` to your deps in `mix.exs`:
 
-    {:mojito, "~> 0.4.0"}
+    {:mojito, "~> 0.5.0"}
 
-## Upgrading from 0.2
+## Upgrading from 0.4 and earlier
 
-Using request methods other than those in the `Mojito` module is deprecated.
-A handful of new config parameters appeared as well.
+Upgrading from 0.4 to 0.5 requires no end-user code changes.
 
-Upgrading 0.2 to 0.4 cannot be performed safely inside a hot upgrade.
+Mojito 0.5 refactors some internal functions in a way that changes
+their arity and order of arguments.
+
+Upgrading to 0.5 cannot be performed safely inside a hot upgrade.
 Deploy a regular release instead.
+
+Using request methods other than those in the `Mojito` module is
+deprecated since 0.3.
+
+A handful of new config parameters appeared in 0.3 as well.
 
 ## Configuration
 
@@ -173,7 +180,7 @@ Heartfelt thanks to everyone who's helped make Mojito better.
 
 ## Authorship and License
 
-Copyright 2019, Appcues, Inc.
+Copyright 2018-2019, Appcues, Inc.
 
 This software is released under the MIT License.
 

--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -48,15 +48,22 @@ defmodule Mojito do
 
   Add `mojito` to your deps in `mix.exs`:
 
-      {:mojito, "~> 0.4.0"}
+      {:mojito, "~> 0.5.0"}
 
-  ## Upgrading from 0.2
+  ## Upgrading from 0.4 and earlier
 
-  Using request methods other than those in the `Mojito` module is deprecated.
-  A handful of new config parameters appeared as well.
+  Upgrading from 0.4 to 0.5 requires no end-user code changes.
 
-  Upgrading 0.2 to 0.4 cannot be performed safely inside a hot upgrade.
+  Mojito 0.5 refactors some internal functions in a way that changes
+  their arity and order of arguments.
+
+  Upgrading to 0.5 cannot be performed safely inside a hot upgrade.
   Deploy a regular release instead.
+
+  Using request methods other than those in the `Mojito` module is
+  deprecated since 0.3.
+
+  A handful of new config parameters appeared in 0.3 as well.
 
   ## Configuration
 
@@ -176,7 +183,7 @@ defmodule Mojito do
 
   ## Authorship and License
 
-  Copyright 2019, Appcues, Inc.
+  Copyright 2018-2019, Appcues, Inc.
 
   This software is released under the MIT License.
   """

--- a/lib/mojito/config.ex
+++ b/lib/mojito/config.ex
@@ -4,6 +4,6 @@ defmodule Mojito.Config do
   def timeout do
     Application.get_env(:mojito, :timeout, 5000)
   end
-
-  ## pool_opts are handled in Mojito.Pool
 end
+
+## pool_opts are handled in Mojito.Pool

--- a/lib/mojito/conn.ex
+++ b/lib/mojito/conn.ex
@@ -53,24 +53,17 @@ defmodule Mojito.Conn do
   a reference to this request (which is required when receiving pipelined
   responses).
   """
-  @spec request(
-          t,
-          atom | String.t(),
-          String.t(),
-          [{String.t(), String.t()}],
-          String.t(),
-          Keyword.t()
-        ) :: {:ok, t, reference} | {:error, any}
-  def request(conn, method, url, headers, body, _opts \\ []) do
+  @spec request(t, Mojito.request()) :: {:ok, t, reference} | {:error, any}
+  def request(conn, request) do
     with {:ok, relative_url, auth_headers} <-
-           Utils.get_relative_url_and_auth_headers(url),
+           Utils.get_relative_url_and_auth_headers(request.url),
          {:ok, mint_conn, request_ref} <-
            Mint.HTTP.request(
              conn.conn,
-             method_to_string(method),
+             method_to_string(request.method),
              relative_url,
-             auth_headers ++ headers,
-             body
+             auth_headers ++ request.headers,
+             request.body
            ) do
       {:ok, %{conn | conn: mint_conn}, request_ref}
     end

--- a/lib/mojito/request/single.ex
+++ b/lib/mojito/request/single.ex
@@ -21,15 +21,10 @@ defmodule Mojito.Request.Single do
   @spec request(Mojito.request()) ::
           {:ok, Mojito.response()} | {:error, Mojito.error()}
   def request(%Request{} = req) do
-    opts = req.opts || []
-    headers = req.headers || []
-    body = req.body || ""
-
-    timeout = opts[:timeout] || Config.timeout()
-
-    with {:ok, conn} <- Conn.connect(req.url, opts),
-         {:ok, conn, _ref} <-
-           Conn.request(conn, req.method, req.url, headers, body, opts) do
+    with {:ok, req} <- Request.validate_request(req),
+         {:ok, conn} <- Conn.connect(req.url, req.opts),
+         {:ok, conn, _ref} <- Conn.request(conn, req) do
+      timeout = req.opts[:timeout] || Config.timeout()
       receive_response(conn, %Response{}, timeout)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Mojito.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @repo_url "https://github.com/appcues/mojito"
 
   def project do

--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -249,6 +249,12 @@ defmodule MojitoTest do
       )
     end
 
+    it "handles requests after a timeout" do
+      assert({:error, %{reason: :timeout}} = get("/wait?d=10", timeout: 1))
+      Process.sleep(100)
+      assert({:ok, %{body: "Hello Alice!"}} = get("?name=Alice"))
+    end
+
     it "handles URL query params" do
       assert({:ok, %{body: "Hello Alice!"}} = get("/?name=Alice"))
       assert({:ok, %{body: "Hello Alice!"}} = get("?name=Alice"))


### PR DESCRIPTION
This PR adds a unique reference to every `:mojito_response` message sent, so that the receiver can match on the reference to ensure the response is associated with the current request and not a request that timed out in the past.  (EDIT: this is handled internally and does not require end user changes.)

It was also a convenient time to do some refactoring to use `%Mojito.Request{}` structs more consistently across internal functions, so I did that too.  The external surface of Mojito did not change.

Fixes #32.