### PR TITLE
Updates docs for Mojito.post with a json payload

### DIFF
--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -360,7 +360,7 @@ defmodule Mojito do
       >>>> Mojito.post(
       ...>   "http://localhost:4000/api/messages",
       ...>   [{"content-type", "application/json"}],
-      ...>   Jason.encode(%{"message" => %{"subject" => "Contact request", "content" => "data"}}))
+      ...>   Jason.encode!(%{"message" => %{"subject" => "Contact request", "content" => "data"}}))
       {:ok,
        %Mojito.Response{
          body: "{\"message\": \"Thank you!\"}",


### PR DESCRIPTION
The docs for `Mojito.post` pass the result of `Jason.encode/1` in the body. This results in an error: `{:error, %Mojito.Error{message: "body must be a UTF-8 string", reason: nil}}` because `Jason.encode/1` returns `{:ok, String.t()} | {:error, EncodeError.t() | Exception.t()}`.

I think the docs should either use `Jason.encode!/1`, or call `Jason.encode/1` and grab the body out of the tuple in the line above.