### PR TITLE
Convert header values to string

### DIFF
--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -277,7 +277,8 @@ defmodule Mojito do
   """
   @spec request(request | request_kwlist) :: {:ok, response} | {:error, error}
   def request(request) do
-    with {:ok, valid_request} <- Mojito.Request.validate_request(request) do
+    with {:ok, valid_request} <- Mojito.Request.validate_request(request),
+         {:ok, valid_request} <- Mojito.Request.convert_headers_values_to_string(valid_request) do
       case Keyword.get(valid_request.opts, :pool, true) do
         true -> Mojito.Pool.Poolboy.request(valid_request)
         false -> Mojito.Request.Single.request(valid_request)

--- a/lib/mojito/headers.ex
+++ b/lib/mojito/headers.ex
@@ -199,4 +199,29 @@ defmodule Mojito.Headers do
     auth64 = "#{username}:#{password}" |> Base.encode64()
     {"authorization", "Basic #{auth64}"}
   end
+
+  @doc ~S"""
+  Convert non string values to string where is possible.
+
+  Example:
+
+      iex> Mojito.Headers.convert_values_to_string([{"content-length", 0}])
+      [{"content-length", "0"}]
+  """
+  @spec convert_values_to_string(headers) :: headers
+  def convert_values_to_string(headers) do
+    convert_values_to_string(headers, [])
+  end
+
+  defp convert_values_to_string([], converted_headers),
+    do: Enum.reverse(converted_headers)
+
+  defp convert_values_to_string([{name, value} | rest], converted_headers)
+       when is_number(value) do
+    convert_values_to_string(rest, [{name, inspect(value)} | converted_headers])
+  end
+
+  defp convert_values_to_string([headers | rest], converted_headers) do
+    convert_values_to_string(rest, [headers | converted_headers])
+  end
 end

--- a/lib/mojito/headers.ex
+++ b/lib/mojito/headers.ex
@@ -218,7 +218,7 @@ defmodule Mojito.Headers do
 
   defp convert_values_to_string([{name, value} | rest], converted_headers)
        when is_number(value) do
-    convert_values_to_string(rest, [{name, inspect(value)} | converted_headers])
+    convert_values_to_string(rest, [{name, to_string(value)} | converted_headers])
   end
 
   defp convert_values_to_string([headers | rest], converted_headers) do

--- a/lib/mojito/headers.ex
+++ b/lib/mojito/headers.ex
@@ -217,7 +217,7 @@ defmodule Mojito.Headers do
     do: Enum.reverse(converted_headers)
 
   defp convert_values_to_string([{name, value} | rest], converted_headers)
-       when is_number(value) do
+       when is_number(value) or is_atom(value) do
     convert_values_to_string(rest, [{name, to_string(value)} | converted_headers])
   end
 

--- a/lib/mojito/request.ex
+++ b/lib/mojito/request.ex
@@ -7,7 +7,7 @@ defmodule Mojito.Request do
             body: "",
             opts: []
 
-  alias Mojito.{Error, Request}
+  alias Mojito.{Error, Headers, Request}
 
   @doc ~S"""
   Checks for errors and returns a canonicalized version of the request.
@@ -53,5 +53,13 @@ defmodule Mojito.Request do
 
   def validate_request(_request) do
     {:error, %Error{message: "request must be a map"}}
+  end
+
+  @doc ~S"""
+  Converts non-string header values to UTF-8 string if possible.
+  """
+  @spec convert_headers_values_to_string(Mojito.request()) :: {:ok, Mojito.request()}
+  def convert_headers_values_to_string(%__MODULE__{headers: headers} = request) do
+    {:ok, %__MODULE__{request | headers: Headers.convert_values_to_string(headers)}}
   end
 end

--- a/lib/mojito/request.ex
+++ b/lib/mojito/request.ex
@@ -59,7 +59,7 @@ defmodule Mojito.Request do
   Converts non-string header values to UTF-8 string if possible.
   """
   @spec convert_headers_values_to_string(Mojito.request()) :: {:ok, Mojito.request()}
-  def convert_headers_values_to_string(%__MODULE__{headers: headers} = request) do
-    {:ok, %__MODULE__{request | headers: Headers.convert_values_to_string(headers)}}
+  def convert_headers_values_to_string(%{headers: headers} = request) do
+    {:ok, %{request | headers: Headers.convert_values_to_string(headers)}}
   end
 end

--- a/test/headers_test.exs
+++ b/test/headers_test.exs
@@ -118,7 +118,7 @@ defmodule Mojito.HeadersTest do
     assert(output == Headers.normalize(@test_headers))
   end
 
-  test "convert_values_to_string converts numbers to string" do
+  test "convert_values_to_string converts numbers and atoms to string" do
     input = [
       {"integer", 2},
       {"float", 22.5},

--- a/test/headers_test.exs
+++ b/test/headers_test.exs
@@ -117,4 +117,22 @@ defmodule Mojito.HeadersTest do
 
     assert(output == Headers.normalize(@test_headers))
   end
+
+  test "convert_values_to_string converts numbers to string" do
+    input = [
+      {"integer", 2},
+      {"float", 22.5},
+      {"atom", :atom},
+      {"string", "string"}
+    ]
+
+    output = [
+      {"integer", "2"},
+      {"float", "22.5"},
+      {"atom", :atom},
+      {"string", "string"}
+    ]
+
+    assert(output == Headers.convert_values_to_string(input))
+  end
 end

--- a/test/headers_test.exs
+++ b/test/headers_test.exs
@@ -123,13 +123,15 @@ defmodule Mojito.HeadersTest do
       {"integer", 2},
       {"float", 22.5},
       {"atom", :atom},
+      {"list", [1,2]},
       {"string", "string"}
     ]
 
     output = [
       {"integer", "2"},
       {"float", "22.5"},
-      {"atom", :atom},
+      {"atom", "atom"},
+      {"list", [1,2]},
       {"string", "string"}
     ]
 


### PR DESCRIPTION
Issue: https://github.com/appcues/mojito/issues/46

If the headers contain non string values, for example `{"content-length", 0}` then Mint will crash with an exception:
```elixir
error] GenServer #PID<0.637.0> terminating
** (FunctionClauseError) no function clause matching in Mint.HTTP1.Request."-validate_header_value!/2-lc$^0/1-0-"/1

Last message (from #PID<0.478.0>): {:request, %Mojito.Request{body: "", headers: [{"x-amz-date", "20191213T171338Z"}, {"content-length", 0}], method: :head, opts: [], url: "https://s3.eu-central-1.amazonaws.com/bucket/file"}, #PID<0.478.0>, #Reference<0.938540534.2258632705.207122>}
State: %{conn: nil, hostname: nil, port: nil, protocol: nil, reply_tos: %{}, response_refs: %{}, responses: %{}}
Client #PID<0.478.0> is alive
```

Mojito can be more permissive and correct the error if it possible to do so unobtrusively. In this PR I am converting number values to string.