### PR TITLE
Add support for request timeout of :infinity

### DIFF
--- a/lib/mojito/request/single.ex
+++ b/lib/mojito/request/single.ex
@@ -45,11 +45,16 @@ defmodule Mojito.Request.Single do
 
   defp handle_msg(conn, response, timeout, msg, start_time) do
     new_timeout = fn ->
-      time_elapsed = time() - start_time
+      case timeout do
+        :infinity ->
+          :infinity
+        _ ->
+          time_elapsed = time() - start_time
 
-      case timeout - time_elapsed do
-        x when x < 0 -> 0
-        x -> x
+          case timeout - time_elapsed do
+            x when x < 0 -> 0
+            x -> x
+          end
       end
     end
 


### PR DESCRIPTION
Issue #35 

Mojito currently doesn't support :infinity as a timeout. These are small changes that should allow it. Tested locally for a project in which we need indefinite timeouts on requests.