### PR TITLE
Always send `nil` body for HEAD/GET/DELETE/OPTIONS requests

### DIFF
--- a/lib/mojito.ex
+++ b/lib/mojito.ex
@@ -336,7 +336,7 @@ defmodule Mojito do
   @spec head(String.t(), headers, Keyword.t()) ::
           {:ok, response} | {:error, error} | no_return
   def head(url, headers \\ [], opts \\ []) do
-    request(:head, url, headers, "", opts)
+    request(:head, url, headers, nil, opts)
   end
 
   @doc ~S"""
@@ -368,7 +368,7 @@ defmodule Mojito do
   @spec get(String.t(), headers, Keyword.t()) ::
           {:ok, response} | {:error, error} | no_return
   def get(url, headers \\ [], opts \\ []) do
-    request(:get, url, headers, "", opts)
+    request(:get, url, headers, nil, opts)
   end
 
   @doc ~S"""
@@ -450,7 +450,7 @@ defmodule Mojito do
   @spec delete(String.t(), headers, Keyword.t()) ::
           {:ok, response} | {:error, error} | no_return
   def delete(url, headers \\ [], opts \\ []) do
-    request(:delete, url, headers, "", opts)
+    request(:delete, url, headers, nil, opts)
   end
 
   @doc ~S"""
@@ -461,6 +461,6 @@ defmodule Mojito do
   @spec options(String.t(), headers, Keyword.t()) ::
           {:ok, response} | {:error, error} | no_return
   def options(url, headers \\ [], opts \\ []) do
-    request(:options, url, headers, "", opts)
+    request(:options, url, headers, nil, opts)
   end
 end


### PR DESCRIPTION
Currently, Mojito sends `""` as the body for HTTP requests which don't need one -- namely `HEAD`, `GET`, `DELETE`, and `OPTIONS`. This was found to combine with certain HTTP/2 and WINDOW_UPDATE situations poorly, manifesting in Mint never sending a `:done` response message, and Mojito subsequently failing with a timeout.

Using `nil` for the body of these requests eliminates the problem. This PR ensures that the request body for the aforementioned HTTP methods is always `nil`.

There is no automated test case for this bug fix because it requires a very particular HTTP/2 setup to replicate. Live testing was performed using `Mojito.get("https://www.monheim.de/typo3conf/ext/ews_podcast/Resources/Public/rss/podcasts.xml")`, the URL mentioned in @Overbryd's bug report linked below.

Fixes #58.