### PR TITLE
Mojito.Pool.Mux

### DIFF
--- a/lib/mojito/application.ex
+++ b/lib/mojito/application.ex
@@ -9,6 +9,10 @@ defmodule Mojito.Application do
       {Registry,
        keys: :duplicate,
        name: Mojito.Pool.Poolboy.Registry,
+       partitions: System.schedulers_online()},
+      {Registry,
+       keys: :duplicate,
+       name: Mojito.Pool.Mux.Registry,
        partitions: System.schedulers_online()}
     ]
 

--- a/lib/mojito/conn_server.ex
+++ b/lib/mojito/conn_server.ex
@@ -20,7 +20,8 @@ defmodule Mojito.ConnServer do
   Example:
 
       {:ok, pid} = Mojito.ConnServer.start_link()
-      :ok = GenServer.cast(pid, {:request, self(), :get, "http://example.com", [], "", []})
+  
+  :ok = GenServer.cast(pid, {:request, self(), :get, "http://example.com", [], "", []})
       receive do
         {:ok, response} -> response
       after
@@ -43,7 +44,12 @@ defmodule Mojito.ConnServer do
 
   #### GenServer callbacks
 
-  def init(_) do
+  def init(opts) do
+    case opts[:register] do
+      {registry, id, value} -> Registry.register(registry, id, value)
+      _ -> :ok
+    end
+
     {:ok,
      %{
        conn: nil,

--- a/lib/mojito/pool/mux.ex
+++ b/lib/mojito/pool/mux.ex
@@ -1,0 +1,57 @@
+defmodule Mojito.Pool.Mux do
+  @moduledoc false
+  @behaviour Mojito.Pool
+
+  alias Mojito.{Config, Request, Utils}
+  require Logger
+
+  @impl Mojito.Pool
+  def request(request) do
+    with {:ok, valid_request} <- Request.validate_request(request),
+         timeout <- get_timeout(valid_request),
+         {:ok, _proto, host, port} <- Utils.decompose_url(valid_request.url),
+         conn_server <- get_conn_server(host, port),
+         response_ref <- make_ref(),
+         :ok <-
+           Mojito.ConnServer.request(conn_server, valid_request, self(), response_ref) do
+      receive do
+        {:mojito_response, ^response_ref, response} -> {:ok, response}
+      after
+        timeout -> {:error, :timeout}
+      end
+    end
+  end
+
+  defp get_timeout(request) do
+    request.opts[:timeout] || Config.timeout()
+  end
+
+  ## Returns the Mojito.ConnServer pid for the given {host, port, scheduler_id},
+  ## launching one if necessary.
+  defp get_conn_server(host, port) do
+    scheduler_id = :erlang.system_info(:scheduler_id)
+    conn_id = {Mojito.Pool.Mux, host, port, scheduler_id}
+
+    case Registry.lookup(Mojito.Pool.Mux.Registry, conn_id) do
+      [{conn_server, true}] ->
+        Logger.debug("found conn_server #{inspect(conn_server)} for #{inspect(conn_id)}")
+        conn_server
+
+      [] ->
+        child_spec = %{
+          id: conn_id,
+          start:
+            {Mojito.ConnServer, :start_link,
+             [[register: {Mojito.Pool.Mux.Registry, conn_id, true}]]},
+          restart: :permanent,
+          shutdown: 5000,
+          type: :worker
+        }
+
+        {:ok, pid} = Supervisor.start_child(Mojito.Supervisor, child_spec)
+        Logger.debug("started conn_server #{inspect(pid)} for #{inspect(conn_id)}")
+
+        pid
+    end
+  end
+end


### PR DESCRIPTION
Mojito.Pool.Mux is a "pool" of one HTTP connection per CPU. It's intended for use with HTTP/2 but can also be used with HTTP/1.1 pipelining, though responses are forced to arrive in order with HTTP/1.1.