### PR TITLE
Add max_body_size param

### DIFF
--- a/lib/mojito/pool/poolboy/single.ex
+++ b/lib/mojito/pool/poolboy/single.ex
@@ -97,6 +97,8 @@ defmodule Mojito.Pool.Poolboy.Single do
 
   * `:timeout` - Request timeout in milliseconds.  Defaults to
     `Application.get_env(:mojito, :timeout, 5000)`.
+  * `:max_body_size` - Max body size in bytes. Defaults to nil in which
+    case no max size will be enforced.
   * `:transport_opts` - Options to be passed to either `:gen_tcp` or `:ssl`.
     Most commonly used to perform insecure HTTPS requests via
     `transport_opts: [verify: :verify_none]`.

--- a/lib/mojito/response.ex
+++ b/lib/mojito/response.ex
@@ -4,7 +4,8 @@ defmodule Mojito.Response do
   defstruct status_code: nil,
             headers: [],
             body: "",
-            complete: false
+            complete: false,
+            size: 0
 
   @type t :: Mojito.response()
 end

--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -249,6 +249,13 @@ defmodule MojitoTest do
       )
     end
 
+    it "can set a max size" do
+      assert(
+        {:error, %Mojito.Error{message: nil, reason: :max_body_size_exceeded}} ==
+        get("/infinite", timeout: 10000, max_body_size: 10)
+      )
+    end
+
     it "handles requests after a timeout" do
       assert({:error, %{reason: :timeout}} = get("/wait?d=10", timeout: 1))
       Process.sleep(100)

--- a/test/pool/poolboy/single_test.exs
+++ b/test/pool/poolboy/single_test.exs
@@ -56,6 +56,15 @@ defmodule Mojito.Pool.Poolboy.SingleTest do
       end)
     end
 
+    it "can get a max body size error" do
+      with_pool(fn pool_name ->
+        assert(
+          {:error, %Mojito.Error{message: nil, reason: :max_body_size_exceeded}} ==
+          get(pool_name, "/infinite", max_body_size: 10)
+        )
+      end)
+    end
+
     it "can saturate pool" do
       with_pool(fn pool_name ->
         spawn(fn -> get(pool_name, "/wait1") end)

--- a/test/support/mojito_test_server.ex
+++ b/test/support/mojito_test_server.ex
@@ -95,6 +95,15 @@ defmodule Mojito.TestServer.PlugRouter do
     send_resp(conn, 200, "ok")
   end
 
+  get "/infinite" do
+    Stream.unfold(send_chunked(conn, 200), fn
+      conn ->
+        {:ok, conn} = chunk(conn, "bytes")
+        {nil, conn}
+    end)
+    |> Stream.run
+  end
+
   @gzip_body "H4sICOnTcF4AA3Jlc3BvbnNlAKtWys9WsiopKk2t5QIAiEF/wgwAAAA="
              |> Base.decode64!()
 


### PR DESCRIPTION
* For convenience there's no streaming interface exposed,
  but that means you can't safely make requests to unknown
  URLs without fear of crashing the VM
* The max_body_size will halt the request if a body gets
  too big
* This is one thing that is preventing me from migrating my company's app from hackney to mint + mojito, which I'd really like to do