### PR TITLE
Handle Connection: Close for pool: false requests

### DIFF
--- a/lib/mojito/request/single.ex
+++ b/lib/mojito/request/single.ex
@@ -37,7 +37,9 @@ defmodule Mojito.Request.Single do
 
     receive do
       {:tcp, _, _} = msg -> handle_msg(conn, response, timeout, msg, start_time)
+      {:tcp_closed, _} = msg -> handle_msg(conn, response, timeout, msg, start_time)
       {:ssl, _, _} = msg -> handle_msg(conn, response, timeout, msg, start_time)
+      {:ssl_closed, _} = msg -> handle_msg(conn, response, timeout, msg, start_time)
     after
       timeout -> {:error, %Error{reason: :timeout}}
     end

--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -331,6 +331,16 @@ defmodule MojitoTest do
       assert({:ok, response} = get("/deflate", raw: true))
       assert("{\"ok\":true}\n" != response.body)
     end
+
+    it "handles connection:close response" do
+      assert({:ok, response} = get("/close", pool: false))
+      assert("close" == response.body)
+    end
+
+    it "handles ssl connection:close response" do
+      assert({:ok, response} = get_ssl("/close", pool: false))
+      assert("close" == response.body)
+    end
   end
 
   context "external tests" do

--- a/test/support/mojito_test_server.ex
+++ b/test/support/mojito_test_server.ex
@@ -44,6 +44,13 @@ defmodule Mojito.TestServer.PlugRouter do
     send_resp(conn, 200, "Hello #{name}!")
   end
 
+  get "/close" do
+    {adapter, req} = conn.adapter
+    {:ok, req} = :cowboy_req.reply(200, [{"connection", "close"}],
+      fn(socket, transport) -> transport.send(socket, "close") end, req)
+    %{conn | adapter: {adapter, req}}
+  end
+
   post "/post" do
     name = conn.body_params["name"] || "Bob"
     send_resp(conn, 200, Jason.encode!(%{name: name}))


### PR DESCRIPTION
See: https://github.com/appcues/mojito/issues/63

There doesn't seem to be an easy way in Plug to force a connection to close and not send the content-length header so I've accessed plug/cowboy internals to do this in the test.

