### PR TITLE
Add request_kwlist to spec for validate_request

### DIFF
--- a/lib/mojito/request.ex
+++ b/lib/mojito/request.ex
@@ -12,7 +12,7 @@ defmodule Mojito.Request do
   @doc ~S"""
   Checks for errors and returns a canonicalized version of the request.
   """
-  @spec validate_request(map | Mojito.request()) ::
+  @spec validate_request(map | Mojito.request() | Mojito.request_kwlist()) ::
           {:ok, Mojito.request()} | {:error, Mojito.error()}
 
   def validate_request(%{} = request) do


### PR DESCRIPTION
I found a mismatch in the specification for `Mojito.Base.request/1` and `Mojito.requestest.validate_request/1`.

**Mojito.Base.request/1**:

```elixir
@spec request(request | request_kwlist) :: {:ok, response} | {:error, error}
def request(request) do
        with {:ok, valid_request} <- Mojito.Request.validate_request(request),
```
The first argument can be a `keyword list`

**Mojito.Request.validate_request/1**:

```elixir
@spec validate_request(map | Mojito.request()) ::
          {:ok, Mojito.request()} | {:error, Mojito.error()}
```
The first argument can be a `map` or a `struct`, but can't be a `keyword list`

