### PR TITLE
add ConnServer.apply_resp/2 error clause

### DIFF
--- a/lib/mojito/conn_server.ex
+++ b/lib/mojito/conn_server.ex
@@ -134,6 +134,10 @@ defmodule Mojito.ConnServer do
     end
   end
 
+  defp apply_resp(state, {:error, request_ref, err}) do
+    halt(state, request_ref, {:error, err})
+  end
+
   defp apply_resp(state, {:done, request_ref}) do
     r = Map.get(state.responses, request_ref)
     body = :erlang.list_to_binary(r.body)


### PR DESCRIPTION
Fix #73 

According to [Mint documentation](https://hexdocs.pm/mint/Mint.HTTP.html#stream/2-responses) the response can be `{error, request_ref, reason}`.

Current implementation calls `ConnServer.apply_response/2`, which does not support an error response.

This PR attempts to implement it.