### PR TITLE
Force GC on pool workers after request completes

### DIFF
--- a/lib/mojito/pool/poolboy/single.ex
+++ b/lib/mojito/pool/poolboy/single.ex
@@ -138,7 +138,11 @@ defmodule Mojito.Pool.Poolboy.Single do
           new_timeout = calc_new_timeout(timeout, start_time) |> max(0)
 
           receive do
-            {:mojito_response, ^response_ref, response} -> response
+            {:mojito_response, ^response_ref, response} ->
+              ## reduce memory footprint of idle pool
+              :erlang.garbage_collect(worker)
+
+              response
           after
             new_timeout -> {:error, :timeout}
           end


### PR DESCRIPTION
It was reported in #76 that Mojito pool workers consumed uncollected memory while they were idle, which can become a problem on memory-constrained systems making requests with large responses. This PR forces garbage collection on each pool worker directly after a request completes. In live testing, this reduced the steady state RAM consumption from ~400MB to ~150MB when downloading a 15MB file repeatedly.

Low RAM usage is not a design goal of Mojito, but this seems like a useful improvement.

Closes #76.