### PR TITLE
Fix pool: false leaking connections

### DIFF
--- a/lib/mojito/conn.ex
+++ b/lib/mojito/conn.ex
@@ -22,6 +22,19 @@ defmodule Mojito.Conn do
   end
 
   @doc ~S"""
+  Closes a connection
+  """
+  @spec close(t) :: :ok
+  def close(conn) do
+    # mint returns an updated conn
+    # but i don't understand why anyone
+    # would care about it. i think they just
+    # close the socket and set state: closed
+    Mint.HTTP.close(conn.conn)
+    :ok
+  end
+
+  @doc ~S"""
   Connects to the server specified in the given URL,
   returning a connection to the server.  No requests are made.
   """

--- a/test/mojito_sync_test.exs
+++ b/test/mojito_sync_test.exs
@@ -1,0 +1,43 @@
+defmodule MojitoSyncTest do
+  use ExSpec, async: false
+  doctest Mojito
+
+  context "local server tests" do
+    @http_port Application.get_env(:mojito, :test_server_http_port)
+
+    defp get(path, opts) do
+      Mojito.get(
+        "http://localhost:#{@http_port}#{path}",
+        [],
+        opts
+      )
+    end
+
+    it "doesn't leak connections with pool: false" do
+      original_open_ports = length(open_tcp_ports(@http_port))
+      assert({:ok, response} = get("/", pool: false))
+      assert(200 == response.status_code)
+
+      final_open_ports = length(open_tcp_ports(@http_port))
+      assert original_open_ports == final_open_ports
+    end
+  end
+
+  defp open_tcp_ports(to_port) do
+    Enum.filter(tcp_sockets(), fn socket ->
+      case :inet.peername(socket) do
+        {:ok, {_ip, ^to_port}} -> true
+        _error -> false
+      end
+    end)
+  end
+
+  defp tcp_sockets() do
+    Enum.filter(:erlang.ports(), fn port ->
+      case :erlang.port_info(port, :name) do
+        {_, 'tcp_inet'} -> true
+        _ -> false
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Ensure Mint.HTTP.close is called

Fix for: https://github.com/appcues/mojito/issues/82

Not sure if this is the best way of testing it. You can comment out `Conn.close` and see the test fail to see the original issue.