### PR TITLE
Extend metadata for `[:mojito, :request, :stop]` event

### DIFF
--- a/lib/mojito/pool/poolboy/single.ex
+++ b/lib/mojito/pool/poolboy/single.ex
@@ -131,6 +131,10 @@ defmodule Mojito.Pool.Poolboy.Single do
 
           request(pool, %{valid_request | opts: new_request_opts})
 
+        {:ok, %Mojito.Response{status_code: status_code}} = response ->
+          Telemetry.stop(:request, start_time, Map.put(meta, :status_code, status_code))
+          response
+
         other ->
           Telemetry.stop(:request, start_time, meta)
           other

--- a/lib/mojito/telemetry.ex
+++ b/lib/mojito/telemetry.ex
@@ -36,7 +36,8 @@ defmodule Mojito.Telemetry do
 
   * `[:mojito, :request, :stop]` after making a request
     - Measurements: `:system_time`, `:duration`
-    - Metadata: `:host`, `:port`, `:path`, `:method`
+    - Metadata: `:host`, `:port`, `:path`, `:method`, `:status_code` (This value
+        is otional. It includes the status code from a `Mojito.Response` struct)
 
   """
 


### PR DESCRIPTION
I think this would be a valuable addition for collecting metrics based on these telemetry events, but feel free to decline if you don't think its in line with the design of these events.  Thanks for all you do!