### PR TITLE
Fix returning HTTP/1.1 connections back to the pool with inflight req…

### DIFF
--- a/lib/mojito/conn.ex
+++ b/lib/mojito/conn.ex
@@ -53,6 +53,16 @@ defmodule Mojito.Conn do
     do: {:error, %Error{message: "bad protocol #{inspect(proto)}"}}
 
   @doc ~S"""
+  Return true if the connection is http/1.1
+  """
+  def is_http11(conn) do
+    case conn.conn do
+      %Mint.HTTP1{} -> true
+      _ -> false
+    end
+  end
+
+  @doc ~S"""
   Initiates a request on the given connection.  Returns the updated Conn and
   a reference to this request (which is required when receiving pipelined
   responses).

--- a/lib/mojito/conn_server.ex
+++ b/lib/mojito/conn_server.ex
@@ -33,6 +33,13 @@ defmodule Mojito.ConnServer do
   end
 
   @doc ~S"""
+  Closes the underlying connection if its a HTTP/1.1 connection.
+  """
+  def close_http11_connection(server_pid) do
+    GenServer.call(server_pid, :close_http11_connection)
+  end
+
+  @doc ~S"""
   Initiates a request.  The `reply_to` pid will receive the response in a
   message of the format `{:ok, %Mojito.Response{}} | {:error, any}`.
   """
@@ -70,6 +77,14 @@ defmodule Mojito.ConnServer do
       {:reply, :ok, state}
     else
       err -> {:reply, err, close_connections(state)}
+    end
+  end
+
+  def handle_call(:close_http11_connection, _from, state) do
+    if Conn.is_http11(state.conn) do
+      {:reply, :ok, close_connections(state)}
+    else
+      {:reply, :ok, state}
     end
   end
 

--- a/lib/mojito/pool/poolboy/single.ex
+++ b/lib/mojito/pool/poolboy/single.ex
@@ -155,7 +155,9 @@ defmodule Mojito.Pool.Poolboy.Single do
 
               response
           after
-            new_timeout -> {:error, :timeout}
+            new_timeout ->
+              ConnServer.close_http11_connection(worker)
+              {:error, :timeout}
           end
 
         e ->

--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -274,6 +274,23 @@ defmodule MojitoTest do
       )
     end
 
+    it "handles requests after a timeout when pooling" do
+      child_spec = Mojito.Pool.Poolboy.Single.child_spec(size: 1)
+      {:ok, pool_pid} = Supervisor.start_child(Mojito.Supervisor, child_spec)
+
+      assert(
+        {:error, %{reason: :timeout}} =
+          get("/wait?d=500", timeout: 1, pool: pool_pid)
+      )
+
+      Process.sleep(100)
+
+      assert(
+        {:ok, %{body: "Hello Alice!"}} =
+          get("?name=Alice", pool: pool_pid, timeout: 5000)
+      )
+    end
+
     it "handles requests after a timeout" do
       assert({:error, %{reason: :timeout}} = get("/wait?d=10", timeout: 1))
       Process.sleep(100)


### PR DESCRIPTION
…uests

If we receive a timeout while waiting for a response then it is possible to
return the connection back to the pool while we are still waitiing for the
response. For HTTP/1.1 this will trigger the pipelining logic within Mint.
However, Mint does not let us call stream_request_body while pipelining
requests. Also, pipelining is not necessarily desirable since the client
has to wait for their previous timed out response to be received before
they are able to receive the response for their new request.