### PR TITLE
fix: 🐛 chunk split

### DIFF
--- a/test/mojito_test.exs
+++ b/test/mojito_test.exs
@@ -376,7 +376,7 @@ defmodule MojitoTest do
     end
 
     it "can POST big bodies over HTTP/2" do
-      big = String.duplicate("x", 5_000_000)
+      big = String.duplicate("é", 2_500_000)
       body = %{name: big}
       assert({:ok, response} = post("/post", body, protocols: [:http2]))
       assert({:ok, map} = Jason.decode(response.body))


### PR DESCRIPTION
When splitting body as string, and the body contains characters that can not be represented in Unicode as a single character,
the chunk size can exceed window size of `HTTP2` stream, see the error below:
```elixir
%Mojito.Error{message: nil, reason: %Mint.HTTPError{module: Mint.HTTP2, reason: {:exceeds_window_size, :request, 65535}}}
```

This PR fix the `exceeds_window_size` error by splitting body as binary, not String(Graphemes).
```elixir
iex> string = "hełło"
"hełło"

iex> String.split_at(string, 3)
{"heł", "ło"}

iex> <<chunk::binary-size(3), rest::binary>> = string
iex> chunk
<<104, 101, 197>>
iex> rest
<<130, 197, 130, 111>>
```
