### PR TITLE
Handle `start_pool` error without crashing

### DIFF
--- a/lib/mojito/pool/poolboy.ex
+++ b/lib/mojito/pool/poolboy.ex
@@ -33,9 +33,12 @@ defmodule Mojito.Pool.Poolboy do
   defp do_request(pool, pool_key, request) do
     case Mojito.Pool.Poolboy.Single.request(pool, request) do
       {:error, %{reason: :checkout_timeout}} ->
-        {:ok, pid} = start_pool(pool_key)
-        Mojito.Pool.Poolboy.Single.request(pid, request)
-
+        case start_pool(pool_key) do
+          {:ok, pid} ->
+            Mojito.Pool.Poolboy.Single.request(pid, request)
+          error ->
+            error
+        end
       other ->
         other
     end


### PR DESCRIPTION
When Mojito can't start a new pool quick enough, it will throw an exception like this:

```
{
  {:badmatch, {:error, %Mojito.Error{message: nil, reason: :checkout_timeout}}}, 
  [
    {Mojito.Pool.Poolboy, :do_request, 3, [file: 'lib/mojito/pool/poolboy.ex', line: 36]},
    {Mojito, :request, 1, [file: 'lib/mojito.ex', line: 199]},
    <... rest of stack trace ...>
}
```

Since the other case for `:checkout_timeout` returns the error without crashing, this was surprising behavior for me and it seems like a bug. I'm proposing to fix it by returning the error according to the spec.

Thanks in advance for taking the time to review this!