### PR TITLE
Mark compatibility with telemetry 1.0.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Mojito.MixProject do
       {:mint, "~> 1.1"},
       {:castore, "~> 0.1"},
       {:poolboy, "~> 1.5"},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:ex_spec, "~> 2.0", only: :test},
       {:jason, "~> 1.0", only: :test},
       {:cowboy, "~> 2.0", only: :test},


### PR DESCRIPTION
Telemetry 1.0 has no changes and purely marks the stability of the API:

  https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md