### PR TITLE
Deprecated: 0.7.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Mojito.MixProject do
   use Mix.Project
 
-  @version "0.7.11"
+  @version "0.7.12"
   @repo_url "https://github.com/appcues/mojito"
 
   def project do


### PR DESCRIPTION
`mix hex.retire` recommends publishing a new version to deprecate.